### PR TITLE
Respect `--ignore-dirs` flag in import analysis

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,10 @@ func main() {
 			return
 		}
 
+		if isIgnored(importPath) {
+			return
+		}
+
 		pkg, err := buildContext.Import(importPath, repo, build.AllowBinary)
 		if err, ok := err.(*build.NoGoError); err != nil && ok {
 			return

--- a/main.go
+++ b/main.go
@@ -37,7 +37,6 @@ func main() {
 	repo := gitRoot()
 
 	pkgSeen := make(map[string]bool)
-	var modifiedPackages []*build.Package
 	buildContext := build.Default
 	for _, f := range files {
 		if isIgnored(f) {
@@ -59,7 +58,6 @@ func main() {
 		}
 
 		pkgSeen[pkg.ImportPath] = true
-		modifiedPackages = append(modifiedPackages, pkg)
 	}
 
 	// TODO: list all packages in the repo, determine dependency tree and filter package list to those that transitively import affected packages
@@ -100,8 +98,8 @@ func main() {
 
 	// filter the package list to those affected
 	var affectedPackages []string
-	for _, p := range modifiedPackages {
-		affectedPackages = append(affectedPackages, p.ImportPath)
+	for path := range pkgSeen {
+		affectedPackages = append(affectedPackages, path)
 	}
 	addedMore := true
 	for addedMore {


### PR DESCRIPTION
Avoid analyzing the imports of files in directories that were explicitly ignored by `--ignore-dirs` flag.